### PR TITLE
Disable Wasm unstable target features according to Rust

### DIFF
--- a/compiler/rustc_target/src/spec/base/wasm.rs
+++ b/compiler/rustc_target/src/spec/base/wasm.rs
@@ -124,6 +124,9 @@ pub fn options() -> TargetOptions {
         // representation, so this is disabled.
         generate_arange_section: false,
 
+        // LLVM has enabled target features by default that are not ready in Rust yet.
+        features: "-multivalue,-reference-types".into(),
+
         ..Default::default()
     }
 }

--- a/compiler/rustc_target/src/spec/targets/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_unknown_emscripten.rs
@@ -20,6 +20,7 @@ pub fn target() -> Target {
         panic_strategy: PanicStrategy::Unwind,
         no_default_libraries: false,
         families: cvs!["unix", "wasm"],
+        features: "-multivalue,-reference-types".into(),
         ..base::wasm::options()
     };
     Target {

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip1_threads.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip1_threads.rs
@@ -57,7 +57,7 @@ pub fn target() -> Target {
     options.entry_name = "__main_void".into();
 
     options.singlethread = false;
-    options.features = "+atomics,+bulk-memory,+mutable-globals".into();
+    options.features = "-multivalue,-reference-types,+atomics,+bulk-memory".into();
 
     Target {
         llvm_target: "wasm32-wasi".into(),

--- a/compiler/rustc_target/src/spec/targets/wasm64_unknown_unknown.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm64_unknown_unknown.rs
@@ -35,7 +35,7 @@ pub fn target() -> Target {
     // Any engine that implements wasm64 will surely implement the rest of these
     // features since they were all merged into the official spec by the time
     // wasm64 was designed.
-    options.features = "+bulk-memory,+mutable-globals,+sign-ext,+nontrapping-fptoint".into();
+    options.features = "-multivalue,-reference-types,+bulk-memory,+nontrapping-fptoint".into();
 
     Target {
         llvm_target: "wasm64-unknown-unknown".into(),


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/rust/pull/127513#issuecomment-2221646733.
I decided to use negative target features instead of switching to `mvp` because that would still allow users to use `mvp` while expecting no target features to be active. Though this breaks `bleeding-edge`, which probably is irrelevant for Rust.

I also went ahead and removed `+mutable-globals` and `+sign-ext`, as these are enabled by default now.